### PR TITLE
Add privacy policy for Shopify app

### DIFF
--- a/shopify-privacy.html
+++ b/shopify-privacy.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+  <!-- Favicon -->
+  <link rel="shortcut icon" href="./assets/favicon/favicon.ico" type="image/x-icon" />
+
+  <!-- Libs CSS -->
+  <link rel="stylesheet" href="./assets/css/libs.bundle.css" />
+
+  <!-- Theme CSS -->
+  <link rel="stylesheet" href="./assets/css/theme.bundle.css" />
+
+  <!-- Title -->
+  <title>Packfleet Shopify App Privacy Policy</title>
+
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-K10RPKWTW3"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-K10RPKWTW3');
+</script>
+</head>
+
+<body>
+    <!-- CONTENT -->
+    <section class="pt-8 pt-md-11 pb-8 pb-md-14">
+      <div class="container">
+        <div class="row align-items-center">
+          <div class="col-12 col-md">
+
+            <!-- Heading -->
+            <h1 class="display-4 mb-2 font-weight-bold">
+Packfleet Shopify App Privacy Policy</h1>
+
+          </div>
+          <div class="col-auto">
+
+
+
+          </div>
+        </div> <!-- / .row -->
+        <div class="row">
+          <p class="font-size-lg text-muted mb-6 mb-md-8">Packfleet Shopify App ("the App”) provides the ability to import orders into Packfleet ("the Service") to merchants who use Shopify to power their stores. This Privacy Policy describes how personal information is collected, used, and shared when you install or use the App in connection with your Shopify-supported store.</p>
+          
+          <h2 class="font-weight-bold">Personal Information the App Collects</h2>
+          
+          <p class="font-size-lg text-muted mb-6 mb-md-8">When you install the App, we are automatically able to access certain types of information from your Shopify account: orders in the past 90 days, and shop locations.
+            <br /><br />
+          Additionally, we collect the following types of personal information from you and/or your customers once you have installed the App: orders in the past 90 days, including recipient details such as name and address.
+          <br /><br />
+          We collect personal information directly from the relevant individual, through your Shopify account, or using the following technologies: “Cookies” are data files that are placed on your device or computer and often include an anonymous unique identifier. For more information about cookies, and how to disable cookies, visit <a href="http://www.allaboutcookies.org">http://www.allaboutcookies.org</a>. “Log files” track actions occurring on the Site, and collect data including your IP address, browser type, Internet service provider, referring/exit pages, and date/time stamps. “Web beacons,” “tags,” and “pixels” are electronic files used to record information about how you browse the Site.</p>
+          
+          <h2 class="font-weight-bold">How Do We Use Your Personal Information?</h2>
+          
+          <p class="font-size-lg text-muted mb-6 mb-md-8">We use the personal information we collect from you and your customers in order to provide the Service and to operate the App.</p>
+          
+          <h2 class="font-weight-bold">Sharing Your Personal Information</h2>
+          
+          <p class="font-size-lg text-muted mb-6 mb-md-8">Your information is not shared with third parties external to Packfleet.
+            <br /><br />
+          However, we may share your Personal Information to comply with applicable laws and regulations, to respond to a subpoena, search warrant or other lawful request for information we receive, or to otherwise protect our rights.</p>
+          
+          <h2 class="font-weight-bold">Your Rights</h2>
+          
+          <p class="font-size-lg text-muted mb-6 mb-md-8">If you are a European resident, you have the right to access personal information we hold about you and to ask that your personal information be corrected, updated, or deleted. If you would like to exercise this right, please contact us through the contact information below.
+            <br /><br />
+          Additionally, if you are a European resident we note that we are processing your information in order to fulfill contracts we might have with you (for example if you make an order through the Site), or otherwise to pursue our legitimate business interests listed above. Additionally, please note that your information will be transferred outside of Europe, including to Canada and the United States.</p>
+          
+          <h2 class="font-weight-bold">Data Retention</h2>
+           
+          <p class="font-size-lg text-muted mb-6 mb-md-8">When you place an order through the Site, we will maintain your Order Information for our records unless and until you ask us to delete this information.</p>
+          
+          <h2 class="font-weight-bold">Changes</h2>
+          
+          <p class="font-size-lg text-muted mb-6 mb-md-8">We may update this privacy policy from time to time in order to reflect, for example, changes to our practices or for other operational, legal or regulatory reasons.</p>
+          
+          <h2 class="font-weight-bold">Contact Us</h2> 
+          
+          <p class="font-size-lg text-muted mb-6 mb-md-8">For more information about our privacy practices, if you have questions, or if you would like to make a complaint, please contact us by e-mail at <a href="mailto:hello@packfleet.com">hello@packfleet.com</a>.</p>
+        </div> <!-- / .row -->
+      </div> <!-- / .container -->
+    </section>
+
+  <!-- JAVASCRIPT -->
+
+  <!-- Vendor JS -->
+  <script src="./assets/js/vendor.bundle.js"></script>
+
+  <!-- Theme JS -->
+  <script src="./assets/js/theme.bundle.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
Based upon the Shopify template provided here: https://shopify.dev/apps/store/privacy/privacy-policy-template.

We can come back and do a full Packfleet web app privacy policy/notice later down the road.